### PR TITLE
Spelling Mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Useful tricks and tipps for Galaxy users
+# Useful tricks and tips for Galaxy users
 
 "You must feel the Force around you." *Yoda*
 


### PR DESCRIPTION
The word "tipps" has been misspelt. The proposed change is removing the letter p so that the word remains as 'tips'.